### PR TITLE
Reduce the number of steps when writing BAM records.

### DIFF
--- a/benchmarks/profile_bam_write_uncompressed.py
+++ b/benchmarks/profile_bam_write_uncompressed.py
@@ -1,0 +1,16 @@
+from htspy.bam import BamReader, BamWriter
+import sys
+
+import cProfile
+
+
+def main():
+    with BamReader(sys.argv[1]) as bam_reader:
+        with BamWriter(sys.argv[2],
+                       bam_reader.header, compresslevel=0) as bam_writer:
+            for record in bam_reader:
+                bam_writer.write(record)
+
+
+if __name__ == "__main__":
+    cProfile.run("main()")

--- a/src/htspy/bam.py
+++ b/src/htspy/bam.py
@@ -172,6 +172,7 @@ class BamWriter:
         self._buffer_size = 0
 
     def close(self):
+        self.flush()
         self._file.close()
 
     def __enter__(self):
@@ -182,6 +183,11 @@ class BamWriter:
 
     def _write_header(self):
         self._file.write(self.header.to_bytes())
+
+    def flush(self):
+        block = self._buffer.getbuffer()[:self._buffer_size]
+        self._file.write_block(block)
+        self._buffer_size = 0
 
     def write(self, bam_record: BamRecord):
         data = bam_record.to_bytes()

--- a/src/htspy/bam.py
+++ b/src/htspy/bam.py
@@ -23,7 +23,7 @@ import typing
 from typing import Dict, Iterator, List, Tuple
 
 from ._bam import BamRecord, bam_iterator
-from .bgzf import BGZFReader, BGZFWriter
+from .bgzf import BGZFReader, BGZFWriter, BGZF_BLOCK_SIZE
 
 
 class BAMFormatError(Exception):
@@ -168,6 +168,8 @@ class BamWriter:
         self._file = BGZFWriter(filename, compresslevel)
         self.header = header
         self._write_header()
+        self._buffer = io.BytesIO(bytes(65536))
+        self._buffer_size = 0
 
     def close(self):
         self._file.close()
@@ -182,4 +184,18 @@ class BamWriter:
         self._file.write(self.header.to_bytes())
 
     def write(self, bam_record: BamRecord):
-        self._file.write_block(bam_record.to_bytes())
+        data = bam_record.to_bytes()
+        data_length = len(data)
+        new_size = self._buffer_size + data_length
+        if new_size > BGZF_BLOCK_SIZE:
+            block = self._buffer.getbuffer()[:self._buffer_size]
+            self._file.write_block(block)
+            self._buffer.seek(0)
+            self._buffer_size = 0
+            if data_length > BGZF_BLOCK_SIZE:
+                # Distribute the data over multiple blocks
+                self._file.write(data)
+                self._file.flush()
+        else:
+            self._buffer.write(data)
+            self._buffer_size = new_size


### PR DESCRIPTION
Writing is still slower than pysam, but at least reading + writing is on par with pysam now for uncompressed bam.
### Checklist
- [ ] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)
