### PR TITLE
Make read name an ASCII string instead of a bytes object.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/htspy/ascii-check"]
+	path = src/htspy/ascii-check
+	url = https://github.com/rhpvorderman/ascii-check.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/htspy/ascii-check"]
-	path = src/htspy/ascii-check
-	url = https://github.com/rhpvorderman/ascii-check.git

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     zip_safe=False,
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    package_data={'htspy': ['*.pyi', "htslib/*.h", "*.h", "ascii-check/*.h"]},
+    package_data={'htspy': ['*.pyi', "htslib/*.h", "*.h"]},
     url="https://github.com/rhpvorderman/htspy",
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     zip_safe=False,
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    package_data={'htspy': ['*.pyi', "htslib/*.h", "*.h"]},
+    package_data={'htspy': ['*.pyi', "htslib/*.h", "*.h", "ascii-check/*.h"]},
     url="https://github.com/rhpvorderman/htspy",
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",

--- a/src/htspy/_bam.pyi
+++ b/src/htspy/_bam.pyi
@@ -53,8 +53,8 @@ class BamRecord:
     _next_refID: int
     _next_pos: int
     _tlen: int
-    _read_name: bytes
-    _cigar: bytes
+    _read_name: str
+    _cigar: Cigar
     _seq: bytes
     _qual: bytes
     _tags: bytes
@@ -71,10 +71,7 @@ class BamRecord:
     def cigar(self) -> Cigar: ...
 
     @property
-    def query_name(self) -> bytes: ...
-
-    @property
-    def read_name(self) -> bytes: ...
+    def read_name(self) -> str: ...
 
     @property
     def tags(self) -> bytes: ...

--- a/src/htspy/_bammodule.c
+++ b/src/htspy/_bammodule.c
@@ -513,11 +513,11 @@ typedef struct {
     int32_t tlen;
     // The compiler automatically inserts 4 padding bytes here to properly
     // align the PyObject pointers in memory.
-    PyObject * read_name;
-    PyObject * bamcigar;
-    PyObject * seq;
-    PyObject * qual;
-    PyObject * tags;
+    PyObject * read_name;  // str, ASCII
+    PyObject * bamcigar;   // BamCigar
+    PyObject * seq;        // bytes
+    PyObject * qual;       // bytes
+    PyObject * tags;       // bytes
 } BamRecord;
 
 # define BAM_PROPERTIES_STRUCT_START offsetof(BamRecord, block_size)
@@ -531,27 +531,6 @@ BamRecord_dealloc(BamRecord *self) {
     Py_CLEAR(self->qual);
     Py_CLEAR(self->tags);
     Py_TYPE(self)->tp_free((PyObject *)self);
-}
-
-// Convert an ASCII string to a bytes object if necessary.
-static inline PyObject *
-convert_to_new_bytes_reference(PyObject *obj, const char * param_name)
-{
-    if (obj == NULL) {
-        return PyBytes_FromStringAndSize("", 0);
-    }
-    if (PyBytes_CheckExact(obj)) {
-        Py_INCREF(obj);
-        return obj;
-    }
-    if (PyUnicode_CheckExact(obj)) {
-        return PyUnicode_AsASCIIString(obj);
-    }
-    PyErr_Format(PyExc_TypeError, 
-                 "'%s' expected a bytes or str object got: %s",
-                  param_name,
-                  obj->ob_type->tp_name);
-    return NULL;
 }
 
 static int
@@ -572,10 +551,8 @@ BamRecord_init(BamRecord *self, PyObject *args, PyObject *kwargs) {
         &next_reference_id, &next_position)) {
         return -1; 
     }
-    read_name = convert_to_new_bytes_reference(read_name, "read_name");
-    if (read_name == NULL) {
-            return -1;
-    }
+    read_name = PyUnicode_New(0, 127);
+
     self->refID = reference_id;
     self->pos = position;
     self->l_read_name = PyBytes_GET_SIZE(read_name) + 1;
@@ -643,42 +620,8 @@ static PyMemberDef BamRecord_members[] = {
 
 // PROPERTIES
 
-PyDoc_STRVAR(BamRecord_query_name_doc,
-"The name of the aligned read as a string.\n"
-"WARNING: this attribute is a property that converts 'read_name' \n"
-"to ASCII For faster access use the 'read_name' attribute which \n"
-"is an ASCII-encoded bytes object.");
-
-static PyObject * 
-BamRecord_get_query_name(BamRecord * self, void* closure) 
-{
-    return PyUnicode_FromEncodedObject(self->read_name, "ascii", "strict");
-}
-
-static int 
-BamRecord_set_query_name(BamRecord * self, PyObject * new_qname, void* closure) 
-{
-    PyObject * new_read_name = PyUnicode_AsASCIIString(new_qname);
-    if (new_read_name == NULL)
-        return -1;
-    Py_ssize_t read_name_size = PyBytes_GET_SIZE(new_read_name);
-    if (read_name_size > 254) {
-        PyErr_SetString(PyExc_ValueError, 
-            "read_name may not be larger than 254 characters.");
-        Py_DecRef(new_read_name);
-        return -1;
-    }
-    PyObject * old_read_name = self->read_name;
-    self->read_name = new_read_name;
-    Py_DECREF(old_read_name);
-    uint8_t old_l_read_name = self->l_read_name;
-    self->l_read_name = (uint8_t)read_name_size + 1;
-    self->block_size = self->block_size + self->l_read_name - old_l_read_name;
-    return 0;
-}
-
 PyDoc_STRVAR(BamRecord_read_name_doc,
-"The name of the aligned read as an ASCII encoded bytes object.\n");
+"The name of the aligned read as an ASCII string.\n");
 
 static PyObject * 
 BamRecord_get_read_name(BamRecord * self, void* closure) {
@@ -689,11 +632,15 @@ BamRecord_get_read_name(BamRecord * self, void* closure) {
 static int 
 BamRecord_set_read_name(BamRecord * self, PyObject * new_read_name, void* closure) 
 {
-    if (!PyBytes_CheckExact(new_read_name)){
-        PyErr_SetString(PyExc_TypeError, "read_name must be a bytes object");
+    if (!PyUnicode_CheckExact(new_read_name)){
+        PyErr_SetString(PyExc_TypeError, "read_name must be a str object");
         return -1;
     }
-    Py_ssize_t read_name_size = PyBytes_GET_SIZE(new_read_name);
+    if (!PyUnicode_IS_COMPACT_ASCII(new_read_name)) {
+        PyErr_SetString(PyExc_ValueError, "Read name must be a valid ASCII string.");
+        return -1;
+    }
+    Py_ssize_t read_name_size = PyUnicode_GET_LENGTH(new_read_name);
     if (read_name_size > 254) {
         PyErr_SetString(PyExc_ValueError, 
             "read_name may not be larger than 254 characters.");
@@ -833,8 +780,6 @@ PyDoc_STRVAR(BamRecord_is_supplementary_doc,
 GET_FLAG_PROP(BamRecord_is_supplementary, BAM_FSUPPLEMENTARY)
 
 static PyGetSetDef BamRecord_properties[] = {
-    {"query_name", (getter)BamRecord_get_query_name, (setter)BamRecord_set_query_name, 
-     BamRecord_query_name_doc, NULL},
     {"read_name", (getter)BamRecord_get_read_name, (setter)BamRecord_set_read_name,
      BamRecord_read_name_doc, NULL},
     {"tags", (getter)BamRecord_get_tags, (setter)BamRecord_set_tags,
@@ -882,8 +827,8 @@ BamRecord_to_ptr(BamRecord *self, char * dest) {
          BAM_PROPERTIES_STRUCT_SIZE);
     Py_ssize_t cursor = BAM_PROPERTIES_STRUCT_SIZE;
     
-    Py_ssize_t read_name_size = PyBytes_GET_SIZE(self->read_name);
-    memcpy(dest + cursor, PyBytes_AS_STRING(self->read_name), read_name_size);
+    Py_ssize_t read_name_size = PyUnicode_GET_LENGTH(self->read_name);
+    memcpy(dest + cursor, PyUnicode_DATA(self->read_name), read_name_size);
     cursor += read_name_size;
 
     // Terminate read_name with NULL byte
@@ -1114,8 +1059,8 @@ BamIterator_iternext(BamIterator *self){
         return NULL;
     }
     self->pos += BAM_PROPERTIES_STRUCT_SIZE;
-    bam_record->read_name = PyBytes_FromStringAndSize(
-        self->buf + self->pos, bam_record->l_read_name -1);
+    bam_record->read_name = PyUnicode_DecodeASCII(
+        self->buf + self->pos, bam_record->l_read_name -1, "strict");
     self->pos += bam_record->l_read_name;
 
     Py_ssize_t cigar_length = bam_record->n_cigar_op * sizeof(uint32_t);

--- a/src/htspy/_bammodule.c
+++ b/src/htspy/_bammodule.c
@@ -23,7 +23,7 @@
 #include "structmember.h"         // PyMemberDef
 
 #include "_conversions.h"
-#include "ascii-check/ascii_check_short.h"
+#include "ascii_check_short.h"
 
 // Py_SET_SIZE, Py_SET_REFCNT and Py_SET_TYPE where all introduced and 
 // recommended in Python 3.9

--- a/src/htspy/_bammodule.c
+++ b/src/htspy/_bammodule.c
@@ -23,7 +23,7 @@
 #include "structmember.h"         // PyMemberDef
 
 #include "_conversions.h"
-#include "ascii-check/ascii_check.h"
+#include "ascii-check/ascii_check_short.h"
 
 // Py_SET_SIZE, Py_SET_REFCNT and Py_SET_TYPE where all introduced and 
 // recommended in Python 3.9

--- a/src/htspy/ascii_check_short.h
+++ b/src/htspy/ascii_check_short.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2022 Leiden University Medical Center
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to 
+// deal in the Software without restriction, including without limitation the 
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or 
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+// This file is maintained and tested at
+// https://github.com/rhpvorderman/ascii-check
+// Please report bugs and feature requests there.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define ASCII_MASK_8BYTE 0x8080808080808080ULL
+#define ASCII_MASK_4BYTE 0x80808080U
+#define ASCII_MASK_1BYTE 0x80U
+
+/**
+ * @brief Check if a string of given length only contains ASCII characters. 
+ *        Optimized for short strings. (No memory alignment.)
+ *
+ * @param string A char pointer to the start of the string.
+ * @param length The length of the string. This funtion does not check for 
+ *               terminating NULL bytes.
+ * @returns 1 if the string is ASCII-only
+ */
+static int
+string_is_ascii(const char * string, size_t length) {
+    size_t n = length;
+    const char * char_ptr = string;
+    const uint64_t *longword_ptr = (uint64_t *)char_ptr;
+    while (n >= sizeof(uint64_t)) {
+        if (*longword_ptr & ASCII_MASK_8BYTE){
+            return 0;
+        }
+        longword_ptr += 1;
+        n -= sizeof(uint64_t);
+    }
+    char_ptr = (char *)longword_ptr;
+    while (n != 0) {
+        if (*char_ptr & ASCII_MASK_1BYTE) {
+            return 0;
+        }
+        char_ptr += 1;
+        n -= 1;
+    }
+    return 1;
+}

--- a/tests/test_bam.py
+++ b/tests/test_bam.py
@@ -13,7 +13,7 @@ def test_bam_parsing():
     mapq = 99
     bin = 1001  # TODO get realistic value
     flag = BAM_FUNMAP
-    read_name = b"my_forward_read/1"
+    read_name = "my_forward_read/1"
     l_read_name = len(read_name) + 1
     l_seq = 7
     # Seq consists of 7 AA characters
@@ -30,8 +30,9 @@ def test_bam_parsing():
                              reference_id, pos, l_read_name, mapq, bin,
                              n_cigar_op, flag, l_seq, next_reference_id,
                              next_pos, tlen)
-    bam_record_without_block_size = (bam_struct + read_name + b"\x00" +
-                                     cigar.tobytes() + seq + quals + tags)
+    bam_record_without_block_size = (bam_struct + read_name.encode('ascii') +
+                                     b"\x00" + cigar.tobytes() + seq + quals
+                                     + tags)
     block_size = len(bam_record_without_block_size)
     bam_record = struct.pack("<I", block_size) + bam_record_without_block_size
     parsed_record = next(bam_iterator(bam_record))


### PR DESCRIPTION
This adds approx 16ns per record extra. So it is significant for the parsing speed. However due to a custom ASCII check and PyUnicode_New it is still faster than PyUnicode_DecodeASCII. Given that a name really only makes sense as a `str` object, expensive conversion code can be avoided when using the name. 

16 ns per read extra means that this costs an extra second per 60 million reads. That is acceptable. even if read_name is not used.

### Checklist
- [ ] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)
